### PR TITLE
Add workflow dispatch trigger for image build.

### DIFF
--- a/.github/workflows/oci-image-build.yml
+++ b/.github/workflows/oci-image-build.yml
@@ -1,6 +1,7 @@
 ---
 name: 'Build Wireguard Image'
 on:
+  workflow_dispatch:
   schedule:
     - cron: '22 4 * * *'
   push:


### PR DESCRIPTION
What
---
Adds workflow dispatch trigger for build, currently there is a scheduled build to keep the base patched, however after periods of inactivity the auto trigger is turned off, this adds a dispatch trigger that can be used to trigger a build as a stop gap until the next scheduled run.