### PR TITLE
Revert to alpine 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3.18
 
 RUN apk add --no-cache wireguard-tools sudo iptables
 


### PR DESCRIPTION
What
---
Reverts the base to alpine:3.18, 3.19 needs test/coverage and more vetting.

Todo
---
- [ ] Verify with chart
- [ ] Logs should be clear, no warnings

Relates to: #18, #22

Closes: #23 