### PR TITLE
Add iptables-legacy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3
 
-RUN apk add --no-cache wireguard-tools sudo iptables
+RUN apk add --no-cache wireguard-tools sudo iptables-legacy
 
 RUN addgroup -g 1000 wireguard && \
   adduser -u 1000 -G wireguard -h /home/wireguard -D wireguard && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3
 
-RUN apk add --no-cache wireguard-tools sudo iptables-legacy
+RUN apk add --no-cache wireguard-tools sudo iptables-legacy iptables
 
 RUN addgroup -g 1000 wireguard && \
   adduser -u 1000 -G wireguard -h /home/wireguard -D wireguard && \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+OCI_BUILDER_BIN ?= docker buildx
+
+.PHONY: image
+image:
+	$(OCI_BUILDER_BIN) build . -t ghcr.io/bryopsida/wireguard:local


### PR DESCRIPTION
What
---
Adds https://pkgs.alpinelinux.org/package/edge/main/s390x/iptables-legacy to fix warning about masquerade cli arg in chart

![image](https://github.com/bryopsida/oci-wireguard/assets/8363252/7b559c8b-4265-435f-ae52-640ced4d7572)

PostUp and PostDown hooks in chart use MASQUERADE option, the newer Iptables package in alpine 3.19 leaves this out, iptables-legacy is needed in addition to iptables.

Also sets the base to `3.19` instead of `3` 

Closes: #23 

Evidence
---
![image](https://github.com/bryopsida/oci-wireguard/assets/8363252/e5b8602b-904c-479b-93cf-f767c55a0c48)
Dig to internal kube dns server from client connected over wg with alpine 3.19 image with iptables and iptables-legacy installed.
![image](https://github.com/bryopsida/oci-wireguard/assets/8363252/dddaca7c-3b46-4e59-b00a-e794eb114dab)


Todo
---
- [x] Validate in chart no warnings
- [x] Verify client connectivity