### PR TITLE
Revert to alpine 3.18 base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3
+FROM alpine:3.18
 
-RUN apk add --no-cache wireguard-tools sudo iptables-legacy iptables
+RUN apk add --no-cache wireguard-tools sudo
 
 RUN addgroup -g 1000 wireguard && \
   adduser -u 1000 -G wireguard -h /home/wireguard -D wireguard && \


### PR DESCRIPTION
What
---
Reverts to an alpine 3.18, created: https://github.com/bryopsida/oci-wireguard/issues/27 to address supporting 3.19.

3.18 has a little over a year of support/patches left: https://endoflife.date/alpine.