### PR TITLE
adding iptables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.21
 
-RUN apk add --no-cache wireguard-tools sudo
+RUN apk add --no-cache wireguard-tools sudo iptables
 
 RUN addgroup -g 1000 wireguard && \
   adduser -u 1000 -G wireguard -h /home/wireguard -D wireguard && \


### PR DESCRIPTION
Latest image is missing iptables:
```
[#] wg set wg0 private-key /etc/wireguard/privatekey && iptables -t nat -A POSTROUTING -s 10.34.0.0/24 -o eth0 -j MASQUERADE
/usr/bin/wg-quick: line 295: iptables: command not found
```